### PR TITLE
Adjust examples and orb and command descriptons

### DIFF
--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -3,7 +3,7 @@ version: 2.1
 description: >
   Load secrets from 1Password into your CircleCI jobs, through a Connect server, deployed in your infrastructure.
 
-  For more information about setting up Secrets Automation and deploying Connect, more information can be found [here](https://developer.1password.com/docs/connect/get-started).
+  For more information about setting up Secrets Automation and deploying Connect, check out the 1Password Developer Documentation.
 
 # This information will be displayed in the orb registry and is not mandatory.
 display:

--- a/src/commands/export.yml
+++ b/src/commands/export.yml
@@ -1,5 +1,5 @@
 description: >
-  Load a secret and make it available as an environment variable for next steps in the job.
+  Load a secret and make it available as an environment variable for next steps within the same job.
   Unlike the 1password/exec command, 1password/export does not conceal secrets from the logs.
 
 parameters:

--- a/src/examples/install-cli.yml
+++ b/src/examples/install-cli.yml
@@ -9,7 +9,7 @@ usage:
       machine:
         image: ubuntu-2204:current
       steps:
-        - 1password/install
+        - 1password/install-cli
         - checkout
         - run: |
             docker login -u $(op read op://company/docker/username) -p $(op read op://company/docker/password)

--- a/src/examples/override-shell-job.yml
+++ b/src/examples/override-shell-job.yml
@@ -5,7 +5,7 @@ usage:
   version: 2.1
   orbs:
     1password: onepassword/secrets@0.1.0
-    docker: circleci/docker@1.0.0
+    docker: circleci/docker@2.1.4
   jobs:
     deploy:
       machine:
@@ -15,7 +15,8 @@ usage:
         AWS_SECRET_ACCESS_KEY: op://company/app/aws/secret_access_key
       shell: op run -- /bin/bash
       steps:
-        - 1password/install
+        - 1password/install-cli:
+            shell: /bin/bash -eo pipefail
         - checkout
         - docker/build:
             step-name: build image

--- a/src/examples/override-shell-step.yml
+++ b/src/examples/override-shell-step.yml
@@ -9,7 +9,7 @@ usage:
       machine:
         image: ubuntu-2204:current
       steps:
-        - 1password/install
+        - 1password/install-cli
         - checkout
         - run:
             shell: op run -- /bin/bash


### PR DESCRIPTION
This PR brings the following changes based on some feedback on the orb:
- Orb description - Remove the link in the description since it's recommended not to include one in it.
- `export` command - Adjust description to be more clear in terms of making the env vars available to steps within the same job
- Adjust examples to be realistic and reflect the orb's command names.