### PR TITLE
Adjust example snippets and remove review rule exception

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,6 @@ workflows:
           filters: *filters
       - orb-tools/review:
           filters: *filters
-          exclude: "RC006"
       - shellcheck/check:
           filters: *filters
       - orb-tools/publish:

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ jobs:
       AWS_ACCESS_KEY_ID: op://company/app/aws/access_key_id
       AWS_SECRET_ACCESS_KEY: op://company/app/aws/secret_access_key
     steps:
+      - 1password/install-cli
       - checkout
       - 1password/exec:
           command: |
@@ -81,6 +82,7 @@ jobs:
     machine:
         image: ubuntu-2204:current
     steps:
+      - 1password/install-cli
       - checkout
       - 1password/export:
             var-name: AWS_ACCESS_KEY_ID
@@ -134,21 +136,6 @@ When using either the `1password/exec` orb command or the `op run` shell wrapper
 ### How to Contribute
 
 We welcome [issues](https://github.com/1Password/secrets-orb/issues) to and [pull requests](https://github.com/1Password/secrets-orb/pulls) against this repository!
-
-### How to Publish An Update
-1. Merge pull requests with desired changes to the main branch.
-    - For the best experience, squash-and-merge and use [Conventional Commit Messages](https://conventionalcommits.org/).
-2. Find the current version of the orb.
-    - You can run `circleci orb info onepassword/secrets | grep "Latest"` to see the current version.
-3. Create a [new Release](https://github.com/1Password/secrets-orb/releases/new) on GitHub.
-    - Click "Choose a tag" and _create_ a new [semantically versioned](http://semver.org/) tag. (ex: v1.0.0)
-      - We will have an opportunity to change this before we publish if needed after the next step.
-4.  Click _"+ Auto-generate release notes"_.
-    - This will create a summary of all of the merged pull requests since the previous release.
-    - If you have used _[Conventional Commit Messages](https://conventionalcommits.org/)_ it will be easy to determine what types of changes were made, allowing you to ensure the correct version tag is being published.
-5. Now ensure the version tag selected is semantically accurate based on the changes included.
-6. Click _"Publish Release"_.
-    - This will push a new tag and trigger your publishing pipeline on CircleCI.
 
 ## Security
 

--- a/src/examples/exec.yml
+++ b/src/examples/exec.yml
@@ -13,6 +13,7 @@ usage:
         AWS_ACCESS_KEY_ID: op://company/app/aws/access_key_id
         AWS_SECRET_ACCESS_KEY: op://company/app/aws/secret_access_key
       steps:
+        - 1password/install-cli
         - checkout
         - 1password/exec:
             command: |

--- a/src/examples/export.yml
+++ b/src/examples/export.yml
@@ -10,6 +10,7 @@ usage:
       machine:
         image: ubuntu-2204:current
       steps:
+        - 1password/install-cli
         - checkout
         - 1password/export:
             var-name: AWS_ACCESS_KEY_ID


### PR DESCRIPTION
This PR brings two small changes:
- Rule RC006 (regarding a valid source URL) is no longer ignored, since the repo is now public.
- Adjust some example snippets by adding the `1password/install-cli` step to make them valid.

Note: With this PR being merged, we will release version `v1.0.0` of the orb.