### PR TITLE
feat: update the default 1Password CLI version to 2.21.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ jobs:
       image: ubuntu-2204:current
     steps:
       - 1password/install-cli:
-          version: 2.18.0
+          version: 2.21.0
       - checkout
       - run:
           shell: op run -- /bin/bash

--- a/src/commands/install-cli.yml
+++ b/src/commands/install-cli.yml
@@ -4,7 +4,7 @@ description: >
 parameters:
   version:
     type: string
-    default: 2.7.1
+    default: 2.21.0
     description: Version of 1Password CLI that will be installed
   path:
     type: string


### PR DESCRIPTION
Update the default version of the 1Password CLI being installed in the orb from `2.7.1` to `2.21.0` (i.e. the latest stable version) so that 1Password service accounts can be used more easily and with less configuration changes (i.e. having to manually configure the `.yaml` file to use a more recent version).